### PR TITLE
Fix windows line endings in scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ ADD config_override.php.pyt /usr/local/src/config_override.php.pyt
 ADD envtemplate.py /usr/local/bin/envtemplate.py
 ADD init.sh /usr/local/bin/init.sh
 
+RUN sed -i 's/\r//' /usr/local/bin/init.sh
+RUN sed -i 's/\r//' /usr/local/bin/envtemplate.py
+
 RUN chmod u+x /usr/local/bin/init.sh
 
 ADD crons.conf /root/crons.conf


### PR DESCRIPTION
In Docker installed on Windows. When downloading the repository. This can cause an issue with the line endings. 